### PR TITLE
FIX CheckGrantedStatus method

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -444,7 +444,7 @@ func (c *Client) CheckGrantedStatus(eosAccountName string) (accessGranted bool, 
 	c.log.Debugf("Client::CheckGrantedStatus(%s) called", eosAccountName)
 
 	// Check if access was granted
-	ok, err := c.eos.AccessGranted(c.state.EosAccount, eosAccountName)
+	ok, err := c.eos.AccessGranted(eosAccountName, c.state.EosAccount)
 	if err != nil {
 		return false, false, err
 	}
@@ -486,20 +486,6 @@ func (c *Client) CheckGrantedStatus(eosAccountName string) (accessGranted bool, 
 		}
 
 		return true, true, nil
-	}
-
-	// access is not granted, make sure to remove from all the list
-	c.ehr.RemoveUser(eosAccountName)
-	delete(c.state.EncryptionKeys, eosAccountName)
-	for i, v := range c.state.Connections.WithKey {
-		if v == eosAccountName {
-			c.state.Connections.WithKey = append(c.state.Connections.WithKey[:i], c.state.Connections.WithKey[i+1:]...)
-		}
-	}
-	for i, v := range c.state.Connections.WithoutKey {
-		if v == eosAccountName {
-			c.state.Connections.WithoutKey = append(c.state.Connections.WithoutKey[:i], c.state.Connections.WithoutKey[i+1:]...)
-		}
 	}
 
 	return false, false, nil

--- a/client/client.go
+++ b/client/client.go
@@ -491,6 +491,19 @@ func (c *Client) CheckGrantedStatus(eosAccountName string) (accessGranted bool, 
 	return false, false, nil
 }
 
+func (c *Client) RemoveConnection(eosAccountName string) {
+	c.log.Debugf("Removing connection: %s", eosAccountName)
+
+	c.ehr.RemoveUser(eosAccountName)
+	delete(c.state.EncryptionKeys, eosAccountName)
+
+	for i, v := range c.state.Connections.WithKey {
+		if v == eosAccountName {
+			c.state.Connections.WithKey = append(c.state.Connections.WithKey[:i], c.state.Connections.WithKey[i+1:]...)
+		}
+	}
+}
+
 func (c *Client) RequestAccess(to, customData string) error {
 	err := c.request.RequestsKey(to, customData)
 	return err

--- a/cmd/api/token.go
+++ b/cmd/api/token.go
@@ -37,7 +37,7 @@ func (s *storage) tokenAccountCreation(token string) (string, int, error) {
 		return "", code, err
 	}
 	if exists {
-		return "", 403, fmt.Errorf("There is alreay an account tied to provided token")
+		return "", 403, fmt.Errorf("There is already an account tied to provided token")
 	}
 	return id, 200, nil
 }


### PR DESCRIPTION
- FIX CheckGrantedStatus client method
    - Call to eos module had inverted eos accounts in arguments.
    - CheckGrantedStatus shouldn't remove keys if access in yet granted
      on eos as it might be delayed.
- ADD client RemoveConnection method
    - Results with removing the keys. 
- Needed by: https://github.com/iryonetwork/mesi-adapter/pull/10